### PR TITLE
fixing decode_claim_script to accept OP_0

### DIFF
--- a/lib/transaction.py
+++ b/lib/transaction.py
@@ -423,11 +423,11 @@ def decode_claim_script(decoded_script):
     value = None
     claim_id = None
     claim = None
-    if not (0 < decoded_script[op][0] <= opcodes.OP_PUSHDATA4):
+    if not (0 <= decoded_script[op][0] <= opcodes.OP_PUSHDATA4):
         return False
     name = decoded_script[op][1]
     op += 1
-    if not (0 < decoded_script[op][0] <= opcodes.OP_PUSHDATA4):
+    if not (0 <= decoded_script[op][0] <= opcodes.OP_PUSHDATA4):
         return False
     if decoded_script[0][0] in [
         opcodes.OP_SUPPORT_CLAIM,


### PR DESCRIPTION
decode_claim_script function should accept Op code 0 (OP_0) to push data as is allowed in Core ( see https://github.com/lbryio/lbrycrd/blob/master/src/nameclaim.cpp#L58 ) 

This fixes a bug where getvalueforname('') will raise an exception. 

