### PR TITLE
Command getvalueforname should look back six confirms for security

### DIFF
--- a/lib/commands.py
+++ b/lib/commands.py
@@ -32,7 +32,7 @@ import util
 from util import print_msg, format_satoshis, print_stderr
 import lbrycrd
 from lbrycrd import is_address, hash_160_to_bc_address, hash_160, COIN, TYPE_ADDRESS, Hash
-from lbrycrd import TYPE_CLAIM, TYPE_SUPPORT, TYPE_UPDATE
+from lbrycrd import TYPE_CLAIM, TYPE_SUPPORT, TYPE_UPDATE, RECOMMENDED_CLAIMTRIE_HASH_CONFIRMS
 from transaction import Transaction
 from transaction import deserialize as deserialize_transaction, script_GetOp, decode_claim_script
 import paymentrequest
@@ -695,7 +695,7 @@ class Commands:
                     return {'error': "didn't receive a transaction with the proof"}
                 return {'value': {}}
             return {'error': "proof not in result"}
-        height = self.network.get_local_height()
+        height = self.network.get_local_height() - RECOMMENDED_CLAIMTRIE_HASH_CONFIRMS
         block_header = self.network.blockchain.read_header(height)
         blockhash = self.network.blockchain.hash_header(block_header)
         response = self.network.synchronous_get(('blockchain.claimtrie.getvalue', [name, blockhash]))

--- a/lib/lbrycrd.py
+++ b/lib/lbrycrd.py
@@ -45,7 +45,7 @@ TYPE_UPDATE  = 32
 
 # claim related constants
 EXPIRATION_BLOCKS = 262974
-
+RECOMMENDED_CLAIMTRIE_HASH_CONFIRMS = 6
 
 # AES encryption
 EncodeAES = lambda secret, s: base64.b64encode(aes.encryptData(secret,s))


### PR DESCRIPTION
Requesting value of a name at current height is not secure, as someone can create a single block with whatever claimtrie they wanted.  This is the equivalent of waiting for six confirms for a cryptocurrency transaction.