### PR TITLE
new abandon command with txid and nOut

### DIFF
--- a/lib/lbrycrd.py
+++ b/lib/lbrycrd.py
@@ -64,7 +64,6 @@ def decode_claim_id_hex(claim_id_hex):
 def encode_claim_id_hex(claim_id):
     return rev_hex(claim_id.encode('hex'))
 
-
 def strip_PKCS7_padding(s):
     """return s stripped of PKCS7 padding"""
     if len(s)%16 or not s:


### PR DESCRIPTION
New abandon command with several new features:

This utilizes both txid and nOut to pickout the proper claimtrie tx to abandon (just txid is not sufficient)

It does not take amount as input, as the amount to abandon should be calculated automatically, and it does not make sense to abandon less or more than what is being used for the claim.  

It adds the transaction to the wallet, and broadcasts it over the network, so callers of this function (specifically lbrynet) do not need to mess with that. 

It does not use mktx or get_spendable_coins , instead it uses a new wallet function get_spendable_claimtrietx_coin to get the correct unspent, and will only use that unspent which will than be emptied into a new return address if the return address was not specified. 

Further work needed:
Fix updateclaim in a similar manner 

supportclaim and claimname should return txid and nout that refers to the claim, an also broadcat and add the transaction to the wallet

deprecate old commands, and update lbrynet
