### PR TITLE
adding claim id hash function, adds claim_id in getnameclaims

### DIFF
--- a/lib/lbrycrd.py
+++ b/lib/lbrycrd.py
@@ -21,6 +21,7 @@ import hashlib
 import base64
 import re
 import hmac
+import struct 
 
 import version
 from util import print_error, InvalidPassword
@@ -50,6 +51,10 @@ RECOMMENDED_CLAIMTRIE_HASH_CONFIRMS = 6
 # AES encryption
 EncodeAES = lambda secret, s: base64.b64encode(aes.encryptData(secret,s))
 DecodeAES = lambda secret, e: aes.decryptData(secret, base64.b64decode(e))
+
+def claim_id_hash(txid, n):
+    return hash_160(txid + struct.pack('>I',n))
+
 
 def strip_PKCS7_padding(s):
     """return s stripped of PKCS7 padding"""

--- a/lib/tests/test_lbry.py
+++ b/lib/tests/test_lbry.py
@@ -62,9 +62,15 @@ class Test_Lbry(unittest.TestCase):
               }
        
         out = claims.verify_proof(proof,root_hash[::-1].encode('hex'),'a')
+        self.assertEqual(out,True)
 
 
 
-
-
-
+    def test_claimid_hash(self):
+        txid= "4d08012feefec192bdb45495dcedc171a56d369539ce2d589e3e1ec81a882bb4"
+        nout = 1
+        claim_id = "a438fc7701e10e0e5c41d7a342be1190d9bed57b"
+        
+        
+        out = lbrycrd.claim_id_hash(lbrycrd.rev_hex(txid).decode('hex'),nout)
+        self.assertEqual(claim_id,lbrycrd.rev_hex(out.encode('hex')))

--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -951,6 +951,9 @@ class Abstract_Wallet(PrintError):
                         claim_name, claim_value = txout[1][0]
                         output['name'] = claim_name
                         output['value'] = claim_value
+                        claim_id = lbrycrd.claim_id_hash(rev_hex(output['txid']).decode('hex'),output['nOut']) 
+                        claim_id = lbrycrd.rev_hex(claim_id.encode('hex'))
+                        output['claim_id'] = claim_id
                     elif txout[0] & TYPE_SUPPORT:
                         claim_name, claim_id = txout[1][0]
                         output['name'] = claim_name


### PR DESCRIPTION
This adds a claim id hash function, necessary for obtaining the claim id from the txid and nout.  

Add the calculated claim id to getnameclaims for claims. 

Minor fix to add a missed assert in the unit test for verify_proof function. 