### PR TITLE
adding claim id decode/encode functions, fixing get_name_claim function

### DIFF
--- a/lib/lbrycrd.py
+++ b/lib/lbrycrd.py
@@ -52,8 +52,17 @@ RECOMMENDED_CLAIMTRIE_HASH_CONFIRMS = 6
 EncodeAES = lambda secret, s: base64.b64encode(aes.encryptData(secret,s))
 DecodeAES = lambda secret, e: aes.decryptData(secret, base64.b64decode(e))
 
+# get the claim id hash from txid bytes and int n 
 def claim_id_hash(txid, n):
     return hash_160(txid + struct.pack('>I',n))
+
+# deocde a claim_id hex string 
+def decode_claim_id_hex(claim_id_hex):
+    return rev_hex(claim_id_hex).decode('hex')
+
+# encode claim id bytes into hex string
+def encode_claim_id_hex(claim_id):
+    return rev_hex(claim_id.encode('hex'))
 
 
 def strip_PKCS7_padding(s):

--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -950,7 +950,6 @@ class Abstract_Wallet(PrintError):
                         'txid': prevout_hash,
                         'nOut': int(prevout_n),
                         'address': addr,
-                        'category': "name",
                         'amount': float(value)/COIN,
                         'height': tx_height,
                         'expiration height': tx_height + lbrycrd.EXPIRATION_BLOCKS,
@@ -959,21 +958,24 @@ class Abstract_Wallet(PrintError):
                         'is spent': txo in txis,
                     }
                     if txout[0] & TYPE_CLAIM:
+                        output['category']='claim'
                         claim_name, claim_value = txout[1][0]
                         output['name'] = claim_name
                         output['value'] = claim_value
-                        claim_id = lbrycrd.claim_id_hash(rev_hex(output['txid']).decode('hex'),output['nOut']) 
-                        claim_id = lbrycrd.rev_hex(claim_id.encode('hex'))
+                        claim_id = lbrycrd.claim_id_hash(rev_hex(output['txid']).decode('hex'),output['nOut'])
+                        claim_id = lbrycrd.encode_claim_id_hex(claim_id)
                         output['claim_id'] = claim_id
                     elif txout[0] & TYPE_SUPPORT:
+                        output['category']='support'
                         claim_name, claim_id = txout[1][0]
                         output['name'] = claim_name
-                        output['value'] = claim_id
+                        output['claim_id'] = lbrycrd.encode_claim_id_hex(claim_id)
                     elif txout[0] & TYPE_UPDATE:
+                        output['category']='update'
                         claim_name, claim_id, claim_value = txout[1][0]
                         output['name'] = claim_name
                         output['value'] = claim_value
-                        output['claim_id'] = claim_id
+                        output['claim_id'] = lbrycrd.encode_claim_id_hex(claim_id)
                     if not expired:
                         output['blocks to expiration'] = tx_height + lbrycrd.EXPIRATION_BLOCKS - local_height
                     claims.append(output)


### PR DESCRIPTION
Add a function to encode claim id bytes into hex string, and decode hex strings into claim id bytes. 

Change getnameclaims() command to return the claim id's in hex string and return "update","support","claim" for "category"