### PR TITLE
Eliminate the DEFAULT_SERVERS constant.

### DIFF
--- a/lib/__init__.py
+++ b/lib/__init__.py
@@ -2,7 +2,7 @@ from version import LBRYUM_VERSION
 from util import format_satoshis, print_msg, print_error, set_verbosity
 from wallet import Synchronizer, WalletStorage, Wallet, Imported_Wallet
 from coinchooser import COIN_CHOOSERS
-from network import Network, DEFAULT_SERVERS, DEFAULT_PORTS, pick_random_server
+from network import Network, DEFAULT_PORTS, pick_random_server
 from interface import Connection, Interface
 from simple_config import SimpleConfig, get_config, set_config
 import lbrycrd

--- a/lib/simple_config.py
+++ b/lib/simple_config.py
@@ -70,18 +70,18 @@ class SimpleConfig(object):
             self.system_config = read_system_config_function()
 
         # Set self.path and read the user config
-        self.user_config = {}  # for self.get in electrum_path()
-        self.path = self.electrum_path()
+        self.user_config = {}  # for self.get in lbryum_path()
+        self.path = self.lbryum_path()
         self.user_config = read_user_config_function(self.path)
         # Upgrade obsolete keys
         self.fixup_keys({'auto_cycle': 'auto_connect'})
         # Make a singleton instance of 'self'
         set_config(self)
 
-    def electrum_path(self):
-        # Read electrum_path from command line / system configuration
+    def lbryum_path(self):
+        # Read lbryum_path from command line / system configuration
         # Otherwise use the user's default data directory.
-        path = self.get('electrum_path')
+        path = self.get('lbryum_path')
         if path is None:
             path = self.user_dir()
 

--- a/lib/simple_config.py
+++ b/lib/simple_config.py
@@ -9,7 +9,7 @@ from util import user_dir, print_error, print_msg, print_stderr
 SYSTEM_CONFIG_PATH = "/etc/lbryum.conf"
 
 config = None
-
+NULL = object()
 
 def get_config():
     global config
@@ -20,6 +20,13 @@ def set_config(c):
     global config
     config = c
 
+DEFAULT_CONFIG = {
+    'default_servers': {
+        'lbryum1.lbry.io': {'t': '50001'},
+        'lbryum2.lbry.io': {'t': '50001'},
+        'lbryum3.lbry.io': {'t': '50001'},
+    }
+}
 
 class SimpleConfig(object):
     """
@@ -34,8 +41,9 @@ class SimpleConfig(object):
     override config set in 3.)
     """
     def __init__(self, options={}, read_system_config_function=None,
-                 read_user_config_function=None, read_user_dir_function=None):
-
+                 read_user_config_function=None, read_user_dir_function=None,
+                 default_config=None):
+        default_config = default_config if default_config is not None else DEFAULT_CONFIG
         # This lock needs to be acquired for updating and reading the config in
         # a thread-safe way.
         self.lock = threading.RLock()
@@ -53,6 +61,7 @@ class SimpleConfig(object):
 
         # The command line options
         self.cmdline_options = deepcopy(options)
+        self.default_config = deepcopy(default_config)
 
         # Portable wallets don't use a system config
         if self.cmdline_options.get('portable', False):
@@ -112,13 +121,18 @@ class SimpleConfig(object):
         return
 
     def get(self, key, default=None):
+        configs = (
+            self.cmdline_options,
+            self.user_config,
+            self.system_config,
+            self.default_config,
+        )
         with self.lock:
-            out = self.cmdline_options.get(key)
-            if out is None:
-                out = self.user_config.get(key)
-                if out is None:
-                    out = self.system_config.get(key, default)
-        return out
+            for config in configs:
+                out = config.get(key, NULL)
+                if out is not NULL:
+                    break
+        return out if out is not NULL else default
 
     def is_modifiable(self, key):
         return not key in self.cmdline_options

--- a/lib/tests/test_simple_config.py
+++ b/lib/tests/test_simple_config.py
@@ -15,12 +15,12 @@ class Test_SimpleConfig(unittest.TestCase):
     def setUp(self):
         super(Test_SimpleConfig, self).setUp()
         # make sure "read_user_config" and "user_dir" return a temporary directory.
-        self.electrum_dir = tempfile.mkdtemp()
+        self.lbryum_dir = tempfile.mkdtemp()
         # Do the same for the user dir to avoid overwriting the real configuration
         # for development machines with electrum installed :)
         self.user_dir = tempfile.mkdtemp()
 
-        self.options = {"electrum_path": self.electrum_dir}
+        self.options = {"lbryum_path": self.lbryum_dir}
         self._saved_stdout = sys.stdout
         self._stdout_buffer = StringIO()
         sys.stdout = self._stdout_buffer
@@ -29,7 +29,7 @@ class Test_SimpleConfig(unittest.TestCase):
         super(Test_SimpleConfig, self).tearDown()
         # Remove the temporary directory after each test (to make sure we don't
         # pollute /tmp for nothing.
-        shutil.rmtree(self.electrum_dir)
+        shutil.rmtree(self.lbryum_dir)
         shutil.rmtree(self.user_dir)
 
         # Restore the "real" stdout
@@ -57,26 +57,26 @@ class Test_SimpleConfig(unittest.TestCase):
     def test_simple_config_command_line_overrides_everything(self):
         """Options passed by command line override all other configuration
         sources"""
-        fake_read_system = lambda : {"electrum_path": "a"}
-        fake_read_user = lambda _: {"electrum_path": "b"}
+        fake_read_system = lambda : {"lbryum_path": "a"}
+        fake_read_user = lambda _: {"lbryum_path": "b"}
         read_user_dir = lambda : self.user_dir
         config = SimpleConfig(options=self.options,
                               read_system_config_function=fake_read_system,
                               read_user_config_function=fake_read_user,
                               read_user_dir_function=read_user_dir)
-        self.assertEqual(self.options.get("electrum_path"),
-                         config.get("electrum_path"))
+        self.assertEqual(self.options.get("lbryum_path"),
+                         config.get("lbryum_path"))
 
     def test_simple_config_user_config_overrides_system_config(self):
         """Options passed in user config override system config."""
-        fake_read_system = lambda : {"electrum_path": self.electrum_dir}
-        fake_read_user = lambda _: {"electrum_path": "b"}
+        fake_read_system = lambda : {"lbryum_path": self.lbryum_dir}
+        fake_read_user = lambda _: {"lbryum_path": "b"}
         read_user_dir = lambda : self.user_dir
         config = SimpleConfig(options={},
                               read_system_config_function=fake_read_system,
                               read_user_config_function=fake_read_user,
                               read_user_dir_function=read_user_dir)
-        self.assertEqual("b", config.get("electrum_path"))
+        self.assertEqual("b", config.get("lbryum_path"))
 
     def test_simple_config_system_config_ignored_if_portable(self):
         """If electrum is started with the "portable" flag, system
@@ -94,64 +94,64 @@ class Test_SimpleConfig(unittest.TestCase):
         """If no system-wide configuration and no command-line options are
         specified, the user configuration is used instead."""
         fake_read_system = lambda : {}
-        fake_read_user = lambda _: {"electrum_path": self.electrum_dir}
+        fake_read_user = lambda _: {"lbryum_path": self.lbryum_dir}
         read_user_dir = lambda : self.user_dir
         config = SimpleConfig(options={},
                               read_system_config_function=fake_read_system,
                               read_user_config_function=fake_read_user,
                               read_user_dir_function=read_user_dir)
-        self.assertEqual(self.options.get("electrum_path"),
-                         config.get("electrum_path"))
+        self.assertEqual(self.options.get("lbryum_path"),
+                         config.get("lbryum_path"))
 
     def test_cannot_set_options_passed_by_command_line(self):
         fake_read_system = lambda : {}
-        fake_read_user = lambda _: {"electrum_path": "b"}
+        fake_read_user = lambda _: {"lbryum_path": "b"}
         read_user_dir = lambda : self.user_dir
         config = SimpleConfig(options=self.options,
                               read_system_config_function=fake_read_system,
                               read_user_config_function=fake_read_user,
                               read_user_dir_function=read_user_dir)
-        config.set_key("electrum_path", "c")
-        self.assertEqual(self.options.get("electrum_path"),
-                         config.get("electrum_path"))
+        config.set_key("lbryum_path", "c")
+        self.assertEqual(self.options.get("lbryum_path"),
+                         config.get("lbryum_path"))
 
     # noinspection PyPep8
     def test_can_set_options_from_system_config(self):
-        fake_read_system = lambda : {"electrum_path": self.electrum_dir}
+        fake_read_system = lambda : {"lbryum_path": self.lbryum_dir}
         fake_read_user = lambda _: {}
         read_user_dir = lambda : self.user_dir
         config = SimpleConfig(options={},
                               read_system_config_function=fake_read_system,
                               read_user_config_function=fake_read_user,
                               read_user_dir_function=read_user_dir)
-        config.set_key("electrum_path", "c")
-        self.assertEqual("c", config.get("electrum_path"))
+        config.set_key("lbryum_path", "c")
+        self.assertEqual("c", config.get("lbryum_path"))
 
     def test_can_set_options_set_in_user_config(self):
         another_path = tempfile.mkdtemp()
         fake_read_system = lambda : {}
-        fake_read_user = lambda _: {"electrum_path": self.electrum_dir}
+        fake_read_user = lambda _: {"lbryum_path": self.lbryum_dir}
         read_user_dir = lambda : self.user_dir
         config = SimpleConfig(options={},
                               read_system_config_function=fake_read_system,
                               read_user_config_function=fake_read_user,
                               read_user_dir_function=read_user_dir)
-        config.set_key("electrum_path", another_path)
-        self.assertEqual(another_path, config.get("electrum_path"))
+        config.set_key("lbryum_path", another_path)
+        self.assertEqual(another_path, config.get("lbryum_path"))
 
     def test_can_set_options_from_system_config_if_portable(self):
         """If the "portable" flag is set, the user can overwrite system
         configuration options."""
         another_path = tempfile.mkdtemp()
-        fake_read_system = lambda : {"electrum_path": self.electrum_dir}
+        fake_read_system = lambda : {"lbryum_path": self.lbryum_dir}
         fake_read_user = lambda _: {}
         read_user_dir = lambda : self.user_dir
         config = SimpleConfig(options={"portable": True},
                               read_system_config_function=fake_read_system,
                               read_user_config_function=fake_read_user,
                               read_user_dir_function=read_user_dir)
-        config.set_key("electrum_path", another_path)
-        self.assertEqual(another_path, config.get("electrum_path"))
+        config.set_key("lbryum_path", another_path)
+        self.assertEqual(another_path, config.get("lbryum_path"))
 
     def test_user_config_is_not_written_with_read_only_config(self):
         """The user config does not contain command-line options or system
@@ -166,7 +166,7 @@ class Test_SimpleConfig(unittest.TestCase):
                               read_user_dir_function=read_user_dir)
         config.save_user_config()
         contents = None
-        with open(os.path.join(self.electrum_dir, "config"), "r") as f:
+        with open(os.path.join(self.lbryum_dir, "config"), "r") as f:
             contents = f.read()
         result = ast.literal_eval(contents)
         self.assertEqual({"something": "a"}, result)


### PR DESCRIPTION
Even worse, the ONLINE_SERVERS variable was calculated at import time
making it very difficult to change by a caller.  I got rid of that
too.

Instead, it has been replaced by adding a default_config item to the
simple_config, which should allow callers more control.