### PR TITLE
Allow lbryum to download and save the genesis block

### DIFF
--- a/lib/network.py
+++ b/lib/network.py
@@ -702,7 +702,7 @@ class Network(util.DaemonThread):
             if req_if == interface and req_height == response['params'][0]:
                 next_height = self.blockchain.connect_header(data['chain'], response['result'])
                 # If not finished, get the next header
-                if next_height in [True, False]:
+                if next_height is True or next_height is False:
                     self.bc_requests.popleft()
                     if next_height:
                         self.catchup_progress += 1


### PR DESCRIPTION
lbryum bootstraps fine when the chain is long enough that it switches
over to requesting the headers in chunks.

But for a short chain, it fails due to a few reasons.  This commit
fixes those.