### PR TITLE
Fixing autoconnect fuction in network

### DIFF
--- a/lib/network.py
+++ b/lib/network.py
@@ -136,8 +136,7 @@ class Network(util.DaemonThread):
 
     - Member functions get_header(), get_interfaces(), get_local_height(),
           get_parameters(), get_server_height(), get_status_value(),
-          is_connected(), new_blockchain_height(), set_parameters(),
-          stop()
+          is_connected(), set_parameters(), stop()
     """
 
     def __init__(self, config=None):
@@ -254,7 +253,7 @@ class Network(util.DaemonThread):
         sh = self.get_server_height()
         if not sh:
             self.print_error('no height for main interface')
-            return False
+            return True
         lh = self.get_local_height()
         result = (lh - sh) > 1
         if result:
@@ -475,10 +474,6 @@ class Network(util.DaemonThread):
         self.recent_servers.insert(0, server)
         self.recent_servers = self.recent_servers[0:20]
         self.save_recent_servers()
-
-    def new_blockchain_height(self, blockchain_height, i):
-        self.switch_lagging_interface(i.server)
-        self.notify('updated')
 
     def process_response(self, interface, response, callbacks):
         if self.debug:
@@ -714,6 +709,7 @@ class Network(util.DaemonThread):
                     self.bc_requests.popleft()
                     if next_height:
                         self.catchup_progress += 1
+                        self.switch_lagging_interface(interface.server)
                         self.notify('updated')
                     else:
                         interface.print_error("header didn't connect, dismissing interface")


### PR DESCRIPTION
Currently, Auto connect does not immediately connect to a functioning server on startup, if the default server is not reachable / disconnected. 

This fixes the auto connect function, based on 

https://github.com/spesmilo/electrum/commit/6f72fa4e94434950d56a556d7c30b3ac855631ca
https://github.com/spesmilo/electrum/commit/4dd479cf59a82066faedd8c0f0f816419ab31746

It also removes unused function new_blockchain_height