### PR TITLE
catch NotEnoughFunds exception when making claim transactions

### DIFF
--- a/lib/commands.py
+++ b/lib/commands.py
@@ -29,7 +29,7 @@ from functools import wraps
 from decimal import Decimal
 
 import util
-from util import print_msg, format_satoshis, print_stderr
+from util import print_msg, format_satoshis, print_stderr, NotEnoughFunds
 import lbrycrd
 from lbrycrd import is_address, hash_160_to_bc_address, hash_160, COIN, TYPE_ADDRESS, Hash
 from lbrycrd import TYPE_CLAIM, TYPE_SUPPORT, TYPE_UPDATE, RECOMMENDED_CLAIMTRIE_HASH_CONFIRMS
@@ -843,7 +843,10 @@ class Commands:
 
         outputs = [(TYPE_ADDRESS | TYPE_CLAIM,((name,val),claim_addr),amount)]
         coins = self.wallet.get_spendable_coins()
-        tx = self.wallet.make_unsigned_transaction(coins,outputs,self.config,tx_fee,change_addr)
+        try:
+            tx = self.wallet.make_unsigned_transaction(coins,outputs,self.config,tx_fee,change_addr)
+        except NotEnoughFunds: 
+            return {'success':False, 'reason':'Not enough funds'} 
         self.wallet.sign_transaction(tx, self._password)
         if broadcast:
             success,out = self.wallet.sendtx(tx)
@@ -898,7 +901,10 @@ class Commands:
         
         outputs = [(TYPE_ADDRESS | TYPE_SUPPORT,((name,claim_id),claim_addr),amount)]
         coins = self.wallet.get_spendable_coins()
-        tx = self.wallet.make_unsigned_transaction(coins,outputs,self.config,tx_fee,change_addr)
+        try:
+            tx = self.wallet.make_unsigned_transaction(coins,outputs,self.config,tx_fee,change_addr)
+        except NotEnoughFunds:
+            return {'success':False, 'reason':'Not enough funds'}
         self.wallet.sign_transaction(tx, self._password)
         if broadcast:
             success,out = self.wallet.sendtx(tx)
@@ -987,7 +993,11 @@ class Commands:
             # create a dummy tx for the extra amount in order to get the proper inputs to spend 
             dummy_outputs = [(TYPE_ADDRESS | TYPE_UPDATE,((name,claim_id,val),claim_addr),get_inputs_for_amount)]
             coins = self.wallet.get_spendable_coins()
-            dummy_tx = self.wallet.make_unsigned_transaction(coins,dummy_outputs,self.config,tx_fee,change_addr) 
+            try:
+                dummy_tx = self.wallet.make_unsigned_transaction(coins,dummy_outputs,self.config,tx_fee,change_addr)
+            except NotEnoughFunds: 
+                return {'success':False, 'reason':'Not enough funds'} 
+
             # add the unspents to input
             for i in dummy_tx._inputs:
                 inputs.append(i)

--- a/lib/tests/test_commands.py
+++ b/lib/tests/test_commands.py
@@ -1,0 +1,52 @@
+import unittest
+from lib import commands
+from lib import util
+
+
+class MocWallet(object):
+    def get_spendable_coins(self):
+        out = [{'is_support': False, 'prevout_hash': u'a3900bede6252a9c844987bc9c4c1d901611fc831d03c8239ca9c31961cd5105', 'is_update': False, 'address': 'bNy6H2ZioUPxhpcbUAjcJ24XCqBBQicizD', 'coinbase': False, 'height': 77872, 'is_claim': False, 'value': 600, 'prevout_n': 1}]
+        return out
+    def get_spendable_claimtrietx_coin(self, txid, nout):
+        out = {'x_pubkeys': ['ff0488b21e000000000000000000b0d157dd75c32e0ffeb037e52a27177b597d4cc547b4643e7fb377b2d79b078f0238609014cf243c8cdf7c1b24d0d9f7db295fed6e16e5088cc76069e1852ff20300003104'], 'signatures': [None], 'prevout_hash': '13a78af0e3f29e04e416ac47bd4196a2a476bdc1cf05b4be476ace2ab5de942b', 'is_update': 0, 'claim_value': 'test', 'claim_name': 'testpub12-14-2016-1320', 'redeemPubkey': u'037ab1ba72039546e640317961ed7bdaa062502d4ba3fb036ba0c2e0b24d1b1669', 'value': 1000, 'is_support': 0, 'address': 'bHU9jNvYABJhY93xDXDqT2bFzAs31QMWiL', 'num_sig': 1, 'pubkeys': [u'037ab1ba72039546e640317961ed7bdaa062502d4ba3fb036ba0c2e0b24d1b1669'], 'is_claim': 8, 'prevout_n': 0}
+        return out
+    def make_unsigned_transaction(self, coins, outputs, config, tx_fee, change_addr):
+        raise util.NotEnoughFunds()
+
+class MocNetwork(object):
+    pass
+
+
+class MocCommands(commands.Commands):
+    def __init__(self,wallet,network):
+        self.wallet = wallet
+        self.network = network
+        self.config = {}
+
+
+class Test_Commands(unittest.TestCase):
+
+    # test that NotEnoughFunds exceptions are caught in claim commands
+    def test_claim_not_enough_funds(self):
+        network = MocNetwork()
+        wallet = MocWallet()
+        cmds = MocCommands(wallet, network)
+
+        out = cmds.claim('test', 'value', 1, claim_addr='', change_addr='')
+        self.assertEqual(False, out['success'])
+        self.assertEqual('Not enough funds', out['reason'])
+
+        out = cmds.update('13a78af0e3f29e04e416ac47bd4196a2a476bdc1cf05b4be476ace2ab5de942b',0,'test','d13d485b18f0b7a8ed2482e8f44b533e47948ded','test',1,
+                             claim_addr='', change_addr='', tx_fee=1)
+        self.assertEqual(False, out['success'])
+        self.assertEqual('Not enough funds', out['reason'])
+
+
+        out = cmds.support('test','d13d485b18f0b7a8ed2482e8f44b533e47948ded',1, claim_addr='',change_addr='',tx_fee=1)
+        self.assertEqual(False, out['success'])
+        self.assertEqual('Not enough funds', out['reason'])
+
+
+
+
+


### PR DESCRIPTION
This catches NotEnoughFunds (happens when there is not enough available credits to make a claim) exception when making claim transactions so they can be return instead in the Json output. 

In Lbrynet when making a claim , this code here will now catch the case when there is not enough funds https://github.com/lbryio/lbry/blob/master/lbrynet/core/Wallet.py#L481 