### PR TITLE
raise InvalidProofError

### DIFF
--- a/lib/claims.py
+++ b/lib/claims.py
@@ -37,34 +37,36 @@ def verify_proof(proof, rootHash, name):
         to_hash = ''
         previous_child_character = None
         for child in node['children']:
-            assert not child['character'] < 0 or child['character'] > 255, \
-                InvalidProofError("child character not int between 0 and 255")
+            if child['character'] < 0 or child['character'] > 255:
+                raise InvalidProofError("child character not int between 0 and 255")
             if previous_child_character:
-                assert previous_child_character < child['character'], \
-                    InvalidProofError("children not in increasing order")
+                if previous_child_character >= child['character']:
+                    raise InvalidProofError("children not in increasing order")
             previous_child_character = child['character']
             to_hash += chr(child['character'])
             if 'nodeHash' in child:
-                assert len(child['nodeHash']) == 64, InvalidProofError("invalid child nodeHash")
+                if len(child['nodeHash']) != 64:
+                    raise InvalidProofError("invalid child nodeHash")
                 to_hash += binascii.unhexlify(child['nodeHash'])[::-1]
             else:
-                assert previous_computed_hash is not None, \
-                    InvalidProofError("previous computed hash is None")
-                assert found_child_in_chain is not True, \
-                    InvalidProofError("already found the next child in the chain")
+                if previous_computed_hash is None:
+                    raise InvalidProofError("previous computed hash is None")
+                if found_child_in_chain is True:
+                    raise InvalidProofError("already found the next child in the chain")
                 found_child_in_chain = True
                 reverse_computed_name += chr(child['character'])
                 to_hash += previous_computed_hash
 
         if not found_child_in_chain:
-            assert i == 0, InvalidProofError("did not find the alleged child")
+            if i != 0:
+                raise InvalidProofError("did not find the alleged child")
         if i == 0 and 'txhash' in proof and 'nOut' in proof and 'last takeover height' in proof:
-            assert len(proof['txhash']) == 64, \
-                InvalidProofError("txhash was invalid: {}".format(proof['txhash']))
-            assert isinstance(proof['nOut'], (long, int)), \
-                InvalidProofError("nOut was invalid: {}".format(proof['nOut']))
-            assert isinstance(proof['last takeover height'], (long, int)), \
-                InvalidProofError(
+            if len(proof['txhash']) != 64:
+                raise InvalidProofError("txhash was invalid: {}".format(proof['txhash']))
+            if not isinstance(proof['nOut'], (long, int)):
+                raise InvalidProofError("nOut was invalid: {}".format(proof['nOut']))
+            if not isinstance(proof['last takeover height'], (long, int)):
+                raise InvalidProofError(
                     'last takeover height was invalid: {}'.format(proof['last takeover height']))
             to_hash += get_hash_for_outpoint(
                 binascii.unhexlify(proof['txhash'])[::-1],
@@ -73,16 +75,20 @@ def verify_proof(proof, rootHash, name):
             )
             verified_value = True
         elif 'valueHash' in node:
-            assert len(node['valueHash']) == 64, InvalidProofError("valueHash was invalid")
+            if len(node['valueHash']) != 64:
+                raise InvalidProofError("valueHash was invalid")
             to_hash += binascii.unhexlify(node['valueHash'])[::-1]
 
         previous_computed_hash = Hash(to_hash)
 
-    assert previous_computed_hash == binascii.unhexlify(rootHash)[::-1], InvalidProofError("computed hash does not match roothash")
+    if previous_computed_hash != binascii.unhexlify(rootHash)[::-1]:
+        raise InvalidProofError("computed hash does not match roothash")
     if 'txhash' in proof and 'nOut' in proof:
-        assert verified_value, InvalidProofError("mismatch between proof claim and outcome")
+        if not verified_value:
+            raise InvalidProofError("mismatch between proof claim and outcome")
     if 'txhash' in proof and 'nOut' in proof:
-        assert name == reverse_computed_name[::-1], InvalidProofError("name did not match proof")
-    assert name.startswith(reverse_computed_name[::-1]), InvalidProofError("name fragment does not match proof")
+        if name != reverse_computed_name[::-1]:
+            raise InvalidProofError("name did not match proof")
+    if not name.startswith(reverse_computed_name[::-1]):
+        raise InvalidProofError("name fragment does not match proof")
     return True
-


### PR DESCRIPTION
This was an abuse of assertions. In theory, assertions could be removed
from code and it would function exactly the same. Also, when the
assertion fails, an AssertionError is raised, not the desired
InvalidProofError.