### PR TITLE
Fix lbrynet concurrency issues

### DIFF
--- a/lib/commands.py
+++ b/lib/commands.py
@@ -783,6 +783,7 @@ class Commands:
     name : name to claim 
     val : value the name is set to
     amount : amount to claim
+    broadcast [default = True]: if True, broadcast transaction to the network
     claim_addr [optional] : address where claim will be sent
     tx_fee [optional] : transaction fee 
     change_addr [optional] : address where change amount will be sent
@@ -792,12 +793,13 @@ class Commands:
     reason : if not succesful, give reason
     txid : txid of resulting transaction if succesful
     nout : nout of the resulting support claim if succesful
+    tx: raw tx of the resulting transaction 
     fee : fee paid for the transaction if succesful 
     claimid : claimid of the resulting transaction 
     """
 
     @command('wpn')
-    def claim(self, name, val, amount, claim_addr=None, tx_fee=None, change_addr=None):
+    def claim(self, name, val, amount, broadcast=True, claim_addr=None, tx_fee=None, change_addr=None):
         if claim_addr is None:                   
             claim_addr = self.wallet.create_new_address()
         if change_addr is None:
@@ -814,9 +816,10 @@ class Commands:
         coins = self.wallet.get_spendable_coins()
         tx = self.wallet.make_unsigned_transaction(coins,outputs,self.config,tx_fee,change_addr)
         self.wallet.sign_transaction(tx, self._password)
-        success,out = self.wallet.sendtx(tx) 
-        if not success:
-            return {'success':False,'reason':out}
+        if broadcast:
+            success,out = self.wallet.sendtx(tx)
+            if not success:
+                return {'success':False,'reason':out}
         
         nout = None
         for i,output in enumerate(tx._outputs):
@@ -825,14 +828,15 @@ class Commands:
         assert(nout is not None)
         
         claimid = lbrycrd.encode_claim_id_hex(lbrycrd.claim_id_hash(lbrycrd.rev_hex(tx.hash()).decode('hex'),nout))
-        return {"success":True,"txid":tx.hash(),"nout":nout,"fee":str(Decimal(tx.get_fee())/COIN),
+        return {"success":True,"txid":tx.hash(),"nout":nout,"tx":str(tx),"fee":str(Decimal(tx.get_fee())/COIN),
                 "claimid":claimid}
     """
     support claim 
     Args:
     name : name of claim to support
     claim_id : claim id of claim to support
-    amount : amount to support 
+    amount : amount to support
+    broadcast [default = True]: if True, broadcast transaction to the network
     claim_addr [optional] : address where support claim will be sent
     tx_fee [optional] : transaction fee 
     change_addr [optional] : address where change amount will be sent
@@ -842,11 +846,12 @@ class Commands:
     reason : if not succesful, give reason
     txid : txid of resulting transaction if succesful
     nout : nout of the resulting support claim if succesful
+    tx: raw tx of the resulting transaction 
     fee : fee paid for the transaction if succesful 
     """
 
     @command('wpn')
-    def support(self, name, claim_id, amount, claim_addr=None, tx_fee=None,
+    def support(self, name, claim_id, amount, broadcast=True, claim_addr=None, tx_fee=None,
                      change_addr=None):
         if claim_addr is None:                   
             claim_addr = self.wallet.create_new_address()
@@ -866,16 +871,17 @@ class Commands:
         coins = self.wallet.get_spendable_coins()
         tx = self.wallet.make_unsigned_transaction(coins,outputs,self.config,tx_fee,change_addr)
         self.wallet.sign_transaction(tx, self._password)
-        success,out = self.wallet.sendtx(tx) 
-        if not success:
-            return {'success':False,'reason':out}
+        if broadcast:
+            success,out = self.wallet.sendtx(tx)
+            if not success:
+                return {'success':False,'reason':out}
 
         nout = None
         for i,output in enumerate(tx._outputs):
             if output[0] & TYPE_SUPPORT:
                 nout = i
 
-        return {"success":True,"txid":tx.hash(),"nout":nout,"fee":str(Decimal(tx.get_fee())/COIN)} 
+        return {"success":True,"txid":tx.hash(),"nout":nout,"tx":str(tx),"fee":str(Decimal(tx.get_fee())/COIN)} 
 
     """
     update claim 
@@ -886,21 +892,23 @@ class Commands:
     claim_id : claim id of claim to update
     val : value to update to 
     amount : amount to update to, if set to None, will be the current claim amount - tx_fee 
+    broadcast [default = True]: if True, broadcast transaction to the network
     claim_addr [optional] : address where claim will be sent
     tx_fee [optional] : transaction fee 
     change_addr [optional] : address where change amount is sent
-       
+
     Output:
     success : True if succesful , False otherwise
     reason : if not succesful, give reason
     txid : txid of resulting transaction if succesful
     nout : nout of the resulting claim update if succesful
+    tx: raw tx of the resulting transaction 
     fee : fee paid for the transaction if succesful 
     amount: amount updated to 
     """
 
     @command('wpn')
-    def update(self, txid, nout, name, claim_id, val, amount, claim_addr=None, tx_fee=None,
+    def update(self, txid, nout, name, claim_id, val, amount, broadcast=True, claim_addr=None, tx_fee=None,
                     change_addr=None):
 
         if claim_addr is None:                   
@@ -975,9 +983,10 @@ class Commands:
   
         tx = Transaction.from_io(inputs,outputs)      
         self.wallet.sign_transaction(tx, self._password)
-        success,out = self.wallet.sendtx(tx) 
-        if not success: 
-            return {"success":False, "reason":out} 
+        if broadcast:
+            success,out = self.wallet.sendtx(tx)
+            if not success:
+                return {"success":False, "reason":out}
             
         nout = None
         amount = 0 
@@ -986,7 +995,7 @@ class Commands:
                 nout = i
                 amount = output[2]
 
-        return {"success":True,"txid":tx.hash(),"nout":nout,"fee":str(Decimal(tx.get_fee())/COIN),
+        return {"success":True,"txid":tx.hash(),"nout":nout,"tx":str(tx),"fee":str(Decimal(tx.get_fee())/COIN),
                 "amount":str(Decimal(amount)/COIN),}
 
     """
@@ -994,17 +1003,19 @@ class Commands:
     Args:
     txid : txid of claim to abandon
     nout : nout of claim to abandon
+    broadcast [default = True]: if True, broadcast transaction to the network
     return_addr [optional] : address where amount will be returned
-    tx_fee [optional] : transaction fee 
-       
+    tx_fee [optional] : transaction fee
+
     Output:
     success : True if succesful , False otherwise
     reason : if not succesful, give reason
     txid : txid of resulting transaction if succesful
+    tx: raw tx of the resulting transaction 
     fee : fee paid for the transaction if succesful 
     """
     @command('wpn')
-    def abandon(self, txid, nout, return_addr=None, tx_fee=None):
+    def abandon(self, txid, nout, broadcast=True, return_addr=None, tx_fee=None):
         # create a single new address to abandon into if return_addr was not specified 
         if return_addr is None:
             return_addr = self.wallet.create_new_address()
@@ -1030,10 +1041,11 @@ class Commands:
         outputs = [(TYPE_ADDRESS,return_addr,return_value)]  
         tx = Transaction.from_io(inputs,outputs)         
         self.wallet.sign_transaction(tx, self._password)
-        success,out = self.wallet.sendtx(tx) 
-        if not success:
-            return {'success':False,'reason':out}
-        return {'success':True,'txid':tx.hash(),'fee':str(Decimal(tx.get_fee())/COIN)}
+        if broadcast:
+            success,out = self.wallet.sendtx(tx)
+            if not success:
+                return {'success':False,'reason':out}
+        return {'success':True,'txid':tx.hash(),'tx':str(tx),'fee':str(Decimal(tx.get_fee())/COIN)}
 
 
 param_descriptions = {
@@ -1085,6 +1097,7 @@ command_options = {
     'exclude_claimtrietx':(None,"--exclude_claimtrietx", "Exclude claimtrie transactions"),
     'return_addr': (None, "--return_addr", "Return address where amounts in abandoned claimtrie transactions are returned."),
     'claim_addr':  (None, "--claim_addr",  "Address where claims are sent."),
+    'broadcast':   (None, "--broadcast",   "if True, broadcast the transaction")
 }
 
 

--- a/lib/commands.py
+++ b/lib/commands.py
@@ -704,13 +704,14 @@ class Commands:
 
     @command('n')
     def requestvalueforname(self, name, blockhash):
-        """Request value of name with proof from lbryum server"""
+        """Request and return value of name with proof from lbryum server without verifying proof"""
         return self.network.synchronous_get(('blockchain.claimtrie.getvalue', [name, blockhash]))
 
     @command('n')
     def getvalueforname(self, name):
+        """Request value of name from lbryum server and verify its proof"""
         block_header = self.network.blockchain.read_header(self.network.get_local_height() - RECOMMENDED_CLAIMTRIE_HASH_CONFIRMS)
-        block_hash = self.network.blockchain.hash_header(block_header)      
+        block_hash = self.network.blockchain.hash_header(block_header)
         response = self.requestvalueforname(name,block_hash)
         return Commands._verify_proof(name, block_header['claim_trie_root'], response)
 

--- a/lib/tests/test_lbry.py
+++ b/lib/tests/test_lbry.py
@@ -2,6 +2,7 @@ import unittest
 import binascii
 from lib import lbrycrd
 from lib import claims
+from lib import commands
 
 def get_powhash(input_str):
     out=lbrycrd.PoWHash(input_str)
@@ -62,6 +63,19 @@ class Test_Lbry(unittest.TestCase):
         }
         out = claims.verify_proof(proof,root_hash[::-1].encode('hex'),'a')
         self.assertEqual(out,True)
+
+    def test_commands_wrapper_for_verify_proof(self):
+        result = {}
+        out = commands.Commands._verify_proof('test','test',result)
+        self.assertTrue('error' in out)
+
+        # valid proof and root has taken from test_verify_proof()
+        valid_proof ={'last takeover height': 10, 'txhash': 'bd9fa7ffd57d810d4ce14de76beea29d847b8ac34e8e536802534ecb1ca43b68', 'nodes': [{'children': [{'character': 97}, {'nodeHash': '5aa71fb53f646dd5cbde28fce95d89a0e9720f8ca4f87d66a52aa9e7aa0a1552', 'character': 98}]}, {'children': []}], 'nOut': 0}
+        valid_root_hash='198e65bd4c3b66681fac1b8a0b9850cf28dc5df33a86b67cbd72cc7e5d93ba49'
+        result={'proof':valid_proof,'supports':[]}
+
+        out = commands.Commands._verify_proof('a',valid_root_hash,result)
+        self.assertTrue('error' in out)
 
     def test_claimid_hash(self):
         txid= "4d08012feefec192bdb45495dcedc171a56d369539ce2d589e3e1ec81a882bb4"


### PR DESCRIPTION
Lbryum is not designed to be thread safe. We need to have lbrynet use lbryum in a single threaded manner, except in the case of when lbryum makes a network call to lbryum-server, which can be called on a separate thread asynchronously. 

https://github.com/lbryio/lbryum/commit/ad0662e6b858c48f4c6a180d94d2399347bcc880
This commit adds a broadcast option to the claim command, separating the act of making a transaction, and broadcasting a transaction (  broadcasting a transaction is just a send to lbyum server ). 

https://github.com/lbryio/lbryum/commit/e5fd46e7aa41003248fb77fc9f277c0d0205a432
This commit reorganizes getvalueforname command into multiple functions. getvaluforname command makes a lbryum server call and also accesses internal state.  Thus lbrynet needs to be able to do these things separately.  We create requestvalueforname command which just makes a query to lbryum server to get the proof for the value of name, and we also create a _verify_proof function that does the parsing of the proof from the lbryum server. 

https://github.com/lbryio/lbryum/commit/14bafecf6271da41cf032888005e8a9183881094
This is a simple unit test for the _verify_proof function created in the above commit. 

