### PR TITLE
Warn on unicode

### DIFF
--- a/lib/network.py
+++ b/lib/network.py
@@ -516,7 +516,11 @@ class Network(util.DaemonThread):
 
     def get_index(self, method, params):
         """ hashable index for subscriptions and cache"""
-        return str(method) + (':' + str(params[0]) if params  else '')
+        try:
+            return '{}:{}'.format(method, params[0] if params else '')
+        except UnicodeError:
+            log.warning('Support for non-ascii is limited. Failed to encode {!r}'.format(params[0]))
+            return u'{}:{}'.format(method, params[0] if params else '')
 
     def process_responses(self, interface):
         responses = interface.get_responses()


### PR DESCRIPTION
get_index gets called on the name value in claims
which can be unicode, so str() will fail.

I found this bug trying to call get_nametrie, and this
change fixed it.