### PR TITLE
Fixing bug in getvalueforname

### DIFF
--- a/lib/commands.py
+++ b/lib/commands.py
@@ -710,7 +710,8 @@ class Commands:
     @command('n')
     def getvalueforname(self, name):
         """Request value of name from lbryum server and verify its proof"""
-        block_header = self.network.blockchain.read_header(self.network.get_local_height() - RECOMMENDED_CLAIMTRIE_HASH_CONFIRMS)
+        block_header = self.network.blockchain.read_header(
+            self.network.get_local_height() - RECOMMENDED_CLAIMTRIE_HASH_CONFIRMS + 1)
         block_hash = self.network.blockchain.hash_header(block_header)
         response = self.requestvalueforname(name,block_hash)
         return Commands._verify_proof(name, block_header['claim_trie_root'], response)


### PR DESCRIPTION
getvalueforname was looking back six blocks from the tip, but only needs to look back five, because the current tip counts as a confirm (i.e, if we are on block 50 , the claims on block 50 has 1 confirm, the claims on block 49 has 2 confirms, etc..) 