### PR TITLE
Increase timeout

### DIFF
--- a/lib/network.py
+++ b/lib/network.py
@@ -746,7 +746,7 @@ class Network(util.DaemonThread):
                 # Request headers if it is ahead of our blockchain
                 if not self.bc_request_headers(interface, data):
                     continue
-            elif time.time() - req_time > 10:
+            elif time.time() - req_time > 30:
                 interface.print_error("blockchain request timed out")
                 self.connection_down(interface.server)
                 continue


### PR DESCRIPTION
I have ~850 addresses in my wallet and sending subscriptions for each
one takes more than 10 seconds. There is probably a better solution...