### PR TITLE
Change recommended confirms for claimtrie commands

### DIFF
--- a/lib/lbrycrd.py
+++ b/lib/lbrycrd.py
@@ -46,7 +46,7 @@ TYPE_UPDATE  = 32
 
 # claim related constants
 EXPIRATION_BLOCKS = 262974
-RECOMMENDED_CLAIMTRIE_HASH_CONFIRMS = 6
+RECOMMENDED_CLAIMTRIE_HASH_CONFIRMS = 1
 
 # AES encryption
 EncodeAES = lambda secret, s: base64.b64encode(aes.encryptData(secret,s))


### PR DESCRIPTION
Change recommended confirms for claimtrie commands to be 1, instead of 6. 
Used when calling getvalueforname command to lbryum server. 
Trade off for more responsiveness, over security. 
