### PR TITLE
set default timeout to 30s for lbryum requests

### DIFF
--- a/lib/network.py
+++ b/lib/network.py
@@ -815,7 +815,7 @@ class Network(util.DaemonThread):
         else:
             return local_height
 
-    def synchronous_get(self, request, timeout=100000000):
+    def synchronous_get(self, request, timeout=30):
         queue = Queue.Queue()
         self.send([request], queue.put)
         r = queue.get(True, timeout)


### PR DESCRIPTION
This prevents a non-responsive lbryum request from blocking lbrynet-daemon or the app from shutting down