### PR TITLE
Make supports and updates not spendable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,5 @@ labeled as 2.7.1. Subsequent releases will follow
 [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+ * Fixed user's supports and updates being spendable by other transactions

--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -714,7 +714,7 @@ class Abstract_Wallet(PrintError):
                 tx = self.transactions.get(prevout_hash)
                 tx.deserialize()
                 txout = tx.outputs()[int(prevout_n)]
-                if txout[0] & TYPE_CLAIM == 0 or (abandon_txid is not None and prevout_hash == abandon_txid):
+                if txout[0] & (TYPE_CLAIM | TYPE_SUPPORT | TYPE_UPDATE) == 0 or (abandon_txid is not None and prevout_hash == abandon_txid):
                     output = {
                         'address':addr,
                         'value':value,


### PR DESCRIPTION
wallet.get_spendable_coins() could return coins that were being used either as a support or an update (although it was properly filtering claims), thus wallet could end up abandoning a support or an update when making a new transaction (either a regular send, or a claimtrie transaction)

You can test this easily through lbryum console by typing wallet.get_spendable_coins() , before this pull request, you could clearly see supports and updates being returned as spendable. 
