### PR TITLE
Request individual headers when finished requesting chunks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ labeled as 2.7.1. Subsequent releases will follow
 [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+ * Make requests for individual headers after requesting chunks
+
 ## [2.7.6] - 2017-02-21
 ### Changed
  * Improve packaging of data files to support building with pyinstaller


### PR DESCRIPTION
This fixes the way lbryum requests chunks .

Lbryum will automatically start requesting chunks if it needed more blocks than was in a chunk. However after finishing requesting chunks, it also needed to download the left over headers that did not fit into a chunk ( say  lbryum needs to download 25 blocks and each chunk contained 10 blocks. It would download the first 2 chunks and 20 blocks, but the other 5 would not be downloaded). The leftover blocks would not be downloaded until the lbryum server announced a new height, which happens when a block is mined and that can take two mintues on average. This would make startup time take much longer than usual.

This patch starts requesting individual headers immediately after requesting chunks. It will fix lbry-in-a-oox integration testing which is breaking because of this bug (since lbry-in-a-box starts a fresh lbry install and auto generates 150 blocks which is more than the chunk amount of 96), 

Still need to test to see if this doesn't break anything #