### PR TITLE
Prep work to seperate lbryum process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ labeled as 2.7.1. Subsequent releases will follow
 
 ## [Unreleased]
 ### Added
-  *
-  *
+  * setup.py will install lbryum as a script
+  * added functions for lbrynet in commands.py
   *
 
 ### Changed

--- a/lib/commands.py
+++ b/lib/commands.py
@@ -493,6 +493,14 @@ class Commands:
         return tx
 
     @command('wp')
+    def getunusedaddress(self, account=None):
+        addr = self.wallet.get_unused_address(account)
+        if addr is None:
+            addr = self.wallet.create_new_address()
+            self.wallet.storage.write() 
+        return addr 
+
+    @command('wp')
     def payto(self, destination, amount, tx_fee=None, from_addr=None, change_addr=None, nocheck=False, unsigned=False):
         """Create a raw transaction. """
         domain = [from_addr] if from_addr else None
@@ -787,6 +795,33 @@ class Commands:
     def getblock(self, blockhash):
         """Return a block matching the given blockhash"""
         return self.network.synchronous_get(('blockchain.block.get_block', [blockhash]))
+
+    @command('n')
+    def getbestblockhash(self):
+        height = self.network.get_local_height()
+        if height < 0:
+            return None
+        header = self.network.blockchain.read_header(height)
+        return self.network.blockchain.hash_header(header)
+
+    @command('n')
+    def getmostrecentblocktime(self):
+        height = self.network.get_local_height()
+        if height < 0:
+            return defer.succeed(None)
+        header = self.network.get_header(self.network.get_local_height())
+        return header['timestamp']
+
+    @command('n')
+    def getnetworkstatus(self):
+        out={'is_connecting':self.network.is_connecting(),
+            'is_connected':self.network.is_connected(),
+            'local_height':self.network.get_local_height(),
+            'server_height':self.network.get_server_height(),
+            'blocks_behind':self.network.get_blocks_behind(),
+            'retrieving_headers':self.network.blockchain.retrieving_headers}
+        return out
+
 
     @command('n')
     def getclaimtrie(self):

--- a/lib/daemon.py
+++ b/lib/daemon.py
@@ -66,7 +66,7 @@ class Daemon(DaemonThread):
         self.network = network
         self.gui = None
         self.wallets = {}
-        self.wallet = None
+        self.wallet = self.load_wallet(config.get_wallet_path())
         self.cmd_runner = Commands(self.config, self.wallet, self.network)
         host = config.get('rpchost', 'localhost')
         port = config.get('rpcport', 0)

--- a/lib/plugins.py
+++ b/lib/plugins.py
@@ -36,9 +36,9 @@ class Plugins(DaemonThread):
         DaemonThread.__init__(self)
         if is_local:
             find = imp.find_module('plugins')
-            plugins = imp.load_module('electrum_plugins', *find)
+            plugins = imp.load_module('lbryum_plugins', *find)
         else:
-            plugins = __import__('electrum_plugins')
+            plugins = __import__('lbryum_plugins')
         self.pkgpath = os.path.dirname(plugins.__file__)
         self.config = config
         self.hw_wallets = {}

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ setup(
             'locale/*/LC_MESSAGES/lbryum.mo',
         ]
     },
-    #scripts=['lbryum'],
+    scripts=['lbryum'],
     data_files=data_files,
     description="Lightweight LBRYcrd Wallet",
     author="LBRY Inc.",


### PR DESCRIPTION
It is necessary to launch lbryum as a seperate process from lbrynet, instead of using it as a library. This is the required prep work needed in lbryum. 

commands.py adds functions that are currently defined in lbrynet.core.Wallets, since lbrynet will need to perform all interactions with lbryum through JSON RPC functions defined in commands.py

daemon.py now loads the wallet upon initialization.  

Have setup.py install lbryum as a script. 

Fixed bug in plugins.py which prevented running lbryum as an installed script. 