### PR TITLE
Fix bug in update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ labeled as 2.7.1. Subsequent releases will follow
   * fix return amounts for claim list commands
   * return supports list for claim queries
   * fix bug verifying the claim value for a new certificate claim
+  * fixed update command
 
 ## [2.7.12] - 2017-03-10
 ### Changed

--- a/lib/commands.py
+++ b/lib/commands.py
@@ -1612,7 +1612,7 @@ class Commands:
             dummy_outputs = [
                 (
                     TYPE_ADDRESS | TYPE_UPDATE,
-                    ((name, claim_id, val), claim_addr),
+                    ((name, decoded_claim_id, val), claim_addr),
                     get_inputs_for_amount
                 )
             ]
@@ -1630,7 +1630,7 @@ class Commands:
             outputs = [
                 (
                     TYPE_ADDRESS | TYPE_UPDATE,
-                    ((name, claim_id, val), claim_addr),
+                    ((name, decoded_claim_id, val), claim_addr),
                     amount
                 )
             ]
@@ -1645,7 +1645,7 @@ class Commands:
             dummy_outputs = [
                 (
                     TYPE_ADDRESS | TYPE_UPDATE,
-                    ((name, claim_id, val), claim_addr),
+                    ((name, decoded_claim_id, val), claim_addr),
                     amount
                 ),
                 (
@@ -1664,7 +1664,7 @@ class Commands:
             outputs = [
                 (
                     TYPE_ADDRESS | TYPE_UPDATE,
-                    ((name, claim_id, val), claim_addr),
+                    ((name, decoded_claim_id, val), claim_addr),
                     amount
                 ),
                 (


### PR DESCRIPTION
Claim id's should be decoded , updates don't work without this change.