### PR TITLE
Fix bugs related to get_name_claims() returning supports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ labeled as 2.7.1. Subsequent releases will follow
   * return supports list for claim queries
   * fix bug verifying the claim value for a new certificate claim
   * fixed update command
+  * fix bugs related to get_name_claims() returning supports
 
 ## [2.7.12] - 2017-03-10
 ### Changed

--- a/lib/tests/test_commands.py
+++ b/lib/tests/test_commands.py
@@ -15,7 +15,7 @@ class MocWallet(object):
     def make_unsigned_transaction(self, coins, outputs, config, tx_fee, change_addr):
         raise util.NotEnoughFunds()
 
-    def get_name_claims(self):
+    def get_name_claims(self, domain=None, include_abandoned=True, include_supports=True):
         return []
 
     def create_new_address(self, **kwargs):

--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -996,7 +996,7 @@ class Abstract_Wallet(PrintError):
 
         return h2
 
-    def get_name_claims(self, domain=None):
+    def get_name_claims(self, domain=None, include_abandoned=True, include_supports=True):
         claims = []
         if domain is None:
             domain = self.get_account_addresses(None)
@@ -1010,6 +1010,10 @@ class Abstract_Wallet(PrintError):
                 tx = self.transactions.get(prevout_hash)
                 tx.deserialize()
                 txout = tx.outputs()[int(prevout_n)]
+                if not include_abandoned and txo in txis:
+                    continue
+                if not include_supports and txout[0] & TYPE_SUPPORT:
+                    continue
                 if txout[0] & (TYPE_CLAIM | TYPE_UPDATE | TYPE_SUPPORT):
                     local_height = self.network.get_local_height()
                     expired = tx_height + lbrycrd.EXPIRATION_BLOCKS <= local_height


### PR DESCRIPTION
getcertificateclaims() command needs list of claims with excluded supports. 

updateclaimsignature() command needs list of claims with excluded supports

claim() commands needs list of claims with excluded supports

Added include_supports argument to Wallet.get_name_claims(). Also added include_abandoned argument to Wallet.get_name_claims() since that was a common argument that other commands required. 

getnameclaims() command has include_supports argument. 