### PR TITLE
Changes for running lbryum in daemon mode

### DIFF
--- a/lbryum
+++ b/lbryum
@@ -382,10 +382,5 @@ if __name__ == '__main__':
                 result = run_offline_command(config, config_options)
 
     # print result
-    if type(result) in [str, unicode]:
-        print_msg(result)
-    elif type(result) is dict and result.get('error'):
-        print_stderr(result.get('error'))
-    elif result is not None:
-        print_msg(json_encode(result))
+    print_msg(json_encode(result))
     sys.exit(0)

--- a/lib/commands.py
+++ b/lib/commands.py
@@ -1873,6 +1873,7 @@ def get_parser():
     group.add_argument("-v", "--verbose", action="store_true", dest="verbose", default=False, help="Show debugging information")
     group.add_argument("-P", "--portable", action="store_true", dest="portable", default=False, help="Use local 'electrum_data' directory")
     group.add_argument("-w", "--wallet", dest="wallet_path", help="wallet path")
+    group.add_argument("-D", "--dir", dest="lbryum_path", help="electrum directory")
     # create main parser
     parser = argparse.ArgumentParser(
         parents=[parent_parser],

--- a/lib/daemon.py
+++ b/lib/daemon.py
@@ -137,6 +137,15 @@ class Daemon(DaemonThread):
                     wallet.start_threads(self.network)
             else:
                 wallet = Wallet(storage)
+                # automatically generate wallet for lbrynet
+                if not storage.file_exists:
+                    seed = wallet.make_seed()
+                    wallet.add_seed(seed, None)
+                    wallet.create_master_keys(None)
+                    wallet.create_main_account()
+                    wallet.synchronize()
+
+
                 wallet.start_threads(self.network)
             if wallet:
                 self.wallets[path] = wallet


### PR DESCRIPTION
These changes allow lbryum to run in daemon mode, specifically for use in lbry in a box integration testing. 

Will not affect functionality in lbrynet.

Change in file lbryum allow us to decode all output from daemon as json. 

Change in file lib/commands.py allow us to specify lbryum data path from the command line, for example by calling ./lbryum daemon start -D /pathto/data

Change in lib/daemon.py allow us to create a wallet upon startup of the daemon 