### PR TITLE
fix claimcertificate incase claim fails

### DIFF
--- a/lib/commands.py
+++ b/lib/commands.py
@@ -1312,9 +1312,11 @@ class Commands:
         encoded_claim = claim.serialized.encode('hex')
         result = self.claim(name, encoded_claim, amount, broadcast=broadcast,
                             claim_addr=claim_addr, tx_fee=tx_fee, change_addr=change_addr)
-        self.wallet.save_certificate(result['claim_id'], secp256k1_private_key)
-        self.wallet.set_default_certificate(result['claim_id'],
-                                            overwrite_existing=set_default_certificate)
+
+        if result['success']:
+            self.wallet.save_certificate(result['claim_id'], secp256k1_private_key)
+            self.wallet.set_default_certificate(result['claim_id'],
+                                                overwrite_existing=set_default_certificate)
         return result
 
     @command('wpn')


### PR DESCRIPTION
claimcertificate calls claim, which could return without 'claim_id' field if claim failed and 'success' is false

If claim fails, just return the result from claim without calling wallet.save_certificate or wallet.set_default_certificate  