### PR TITLE
change 'nothing to resolve' error to 'claim not found' 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ labeled as 2.7.1. Subsequent releases will follow
   *
       
 ### Changed
-  *
+  * Change 'nothing to resolve' error to 'claim not found' used in other places
   *
   
 ### Fixed

--- a/lib/commands.py
+++ b/lib/commands.py
@@ -993,7 +993,7 @@ class Commands:
             if 'error' in result[k]:
                 return result[k]
         if not result.get('claim', False) and not result.get('certificate', False) and not result.get('claims_in_channel', False) and not result.get('error', False):
-            return {'error': 'nothing to resolve'}
+            return {'error': 'claim not found'}
         return result
 
     @command('n')


### PR DESCRIPTION
Change error 'nothing to resolve' in getvalueforuri() to 'claim not found' used in other places. 
This applies to when searching for a claim sequence that does not exist (i.e. sometnameclaim:100 ) 