### PR TITLE
Fix getclaimbyoutpoint if no claim exists at outpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ labeled as 2.7.1. Subsequent releases will follow
   *
 
 ### Fixed
-  *
+  * Fixed getclaimbyoutpoint to return error if claim does not exist
   *
 
 ### Deprecated

--- a/lbryum/commands.py
+++ b/lbryum/commands.py
@@ -1166,17 +1166,21 @@ class Commands(object):
     @command('n')
     def getclaimbyoutpoint(self, txid, nout, raw=False):
         """
-        Return claim at outpoint (txid:nout) , return None
-        if it no claim exists at outpoint
+        Return claim at outpoint (txid:nout)
+        If no claim exists at outpoint, or outpoint not found, return
+        dictionary where 'success' is False and 'error' is 'claim not found'
         """
 
         out = self.network.synchronous_get(('blockchain.claimtrie.getclaimsintx', [txid]))
         claims = format_amount_value(format_lbrycrd_keys(out, raw))
+        claim_not_found_out = {'success':False, 'error':'claim not found',
+                               'outpoint':'%s:%i'%(txid, nout)}
         if claims is None:
-            return None
+            return claim_not_found_out
         for claim in claims:
             if claim['nout'] == nout:
                 return self.parse_and_validate_claim_result(claim, raw=raw)
+        return claim_not_found_out
 
     @command('n')
     def getclaimsforname(self, name, raw=False):

--- a/lbryum/commands.py
+++ b/lbryum/commands.py
@@ -1166,11 +1166,14 @@ class Commands(object):
     @command('n')
     def getclaimbyoutpoint(self, txid, nout, raw=False):
         """
-        Return the claims which are in a transaction
+        Return claim at outpoint (txid:nout) , return None
+        if it no claim exists at outpoint
         """
 
         out = self.network.synchronous_get(('blockchain.claimtrie.getclaimsintx', [txid]))
         claims = format_amount_value(format_lbrycrd_keys(out, raw))
+        if claims is None:
+            return None
         for claim in claims:
             if claim['nout'] == nout:
                 return self.parse_and_validate_claim_result(claim, raw=raw)


### PR DESCRIPTION
getclaimbyoutpoint will throw an exception if there is no claim attached to txid (claims becomes None and None is not iterable). 

Return None if no claim exists at txid

