### PR TITLE
Format response in getvalueforuris

### DIFF
--- a/lbryum/commands.py
+++ b/lbryum/commands.py
@@ -1115,9 +1115,10 @@ class Commands(object):
                                                  (block_hash,) + uris_to_send))
         result = {}
         for uri, resolution in response.iteritems():
-            result[uri] = self._handle_resolve_uri_response(parse_lbry_uri(str(uri)), block_header,
+            response = self._handle_resolve_uri_response(parse_lbry_uri(str(uri)), block_header,
                                                             raw, resolution, page=page,
                                                             page_size=page_size)
+            result[uri] = format_amount_value(response)
         return result
 
     @command('n')


### PR DESCRIPTION
Supports and amounts were not being properly formatted when calling getvalueforuris in certain situations. 

Makes sure that format_amount_value is called on every response.

This should fix https://github.com/lbryio/lbry/issues/713 and partially fix https://github.com/lbryio/lbry/issues/750