### PR TITLE
Resolving a channel returns 'channel_claim_count'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ labeled as 2.7.1. Subsequent releases will follow
   *
 
 ### Changed
-  *
+  * Changed uri resolution to return the `claims_in_channel` count instead of the `claims_in_channel_pages` count
   *
 
 ### Added

--- a/lbryum/commands.py
+++ b/lbryum/commands.py
@@ -1010,10 +1010,9 @@ class Commands(object):
                 certificate = result['certificate']
                 if 'unverified_claims_in_channel' in resolution:
                     max_results = len(resolution['unverified_claims_in_channel'])
-                    max_pages = 1 + int((max_results - (max_results % page_size)) / page_size)
-                    result['claims_in_channel_pages'] = max_pages
+                    result['claims_in_channel'] = max_results
                 else:
-                    result['claims_in_channel_pages'] = 0
+                    result['claims_in_channel'] = 0
             else:
                 result['error'] = "claim not found"
                 result['success'] = False


### PR DESCRIPTION
Now, while resolving channel names, no of claims are returned, not no of pages.

Fixes lbryio/lbry#691