### PR TITLE
Fix create new address race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ labeled as 2.7.1. Subsequent releases will follow
   *
 
 ### Fixed
-  *
+  * Fix race condition in create_new_address
   *
 
 ### Deprecated

--- a/lbryum/wallet.py
+++ b/lbryum/wallet.py
@@ -1578,11 +1578,12 @@ class Deterministic_Wallet(Abstract_Wallet):
         return self.accounts['0']
 
     def create_new_address(self, account=None, for_change=0):
-        if account is None:
-            account = self.default_account()
-        address = account.create_new_address(for_change)
-        self.add_address(address)
-        return address
+        with self.lock:
+            if account is None:
+                account = self.default_account()
+            address = account.create_new_address(for_change)
+            self.add_address(address)
+            return address
 
     def add_address(self, address):
         if address not in self.history:


### PR DESCRIPTION
While testing lbry-in-a-box, I discovered that a race condition could cause you to create the same address in your wallet twice. 

This is because the synchronizer, which runs on a seperate thread, will attempt to create a new address if more is needed. : https://github.com/lbryio/lbryum/blob/83e1d5ce1746397b41c66a5500322641f95bf7fd/lbryum/account.py#L67

If you call Wallet.create_new_address() while the synchrhonizer is creating a new address, than you could end up creating two keys from the same n, since n is dependent on how many addresses you have already created.  https://github.com/lbryio/lbryum/blob/83e1d5ce1746397b41c66a5500322641f95bf7fd/lbryum/account.py#L44

Put a lock on Wallet.create_new_address() , since we already have a lock on Wallet.synchronize() , this should be sufficient to keep the two from being called at the same time.

We also need to have a solution that identifies and corrects this problem if it exists in user's wallet.

If you have duplicate keys, it could cause variety of issues such as:  getnameclaims could return the same claim twice, you may have more balance since it will double count balances on a duplicate address, you may not be able to abandon claims because you have two exact same claims. 