### PR TITLE
Correct duplicate addresses in wallet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ labeled as 2.7.1. Subsequent releases will follow
 
 ### Fixed
   * Fix validation of address checksum and prefix when encoding and decoding
-  *
+  * Fix duplicate addreses due to race condition in wallet
 
 ### Deprecated
   *

--- a/lbryum/wallet.py
+++ b/lbryum/wallet.py
@@ -330,6 +330,10 @@ class Abstract_Wallet(PrintError):
                 self.accounts[k] = ImportedAccount(v)
             elif v.get('xpub'):
                 self.accounts[k] = BIP32_Account(v)
+                corrected = self.accounts[k].correct_pubkeys()
+                if corrected:
+                    self.save_accounts()
+
             elif v.get('pending'):
                 removed = True
             else:


### PR DESCRIPTION
Duplicate addresses in the wallet could be created due to a race condition (https://github.com/lbryio/lbryum/pull/147). Also implied is that the duplicate address causes a missing address since BIP32 generates keys sequentially in deterministic manner. This is because when creating a new address, the BIP32 account will check how many addresses it already has to determine what sequence number the new address should use:
  https://github.com/lbryio/lbryum/blob/7be85f4b12d9fe353b7e262db6e69ed1eb80760c/lbryum/account.py#L49

This PR detects if there are problems in the wallet due to this, and corrects it when Wallet is initializing. Detection is fast (look for duplicate keys and also check if pubkey[-1] is equal to derive_pubkey( sequence_number=len(pubkey)-1 ) but correction can take a minute or so if you have a large wallet. We essentially regenerate pubkeys by sequence number until we find all the pubkeys in the original Wallet. 
