### PR TITLE
Fast getnameclaims, speed up commands used to issue claims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ labeled as 2.7.1. Subsequent releases will follow
   *
 
 ### Added
-  *
+  * Added `skip_validate_signatures` parameter to `getnameclaims`
   *
 
 ### Removed

--- a/lbryum/commands.py
+++ b/lbryum/commands.py
@@ -1478,8 +1478,8 @@ class Commands(object):
         # list of claim ids of claims in the wallet
         claim_ids = [c['claim_id'] for c in result]
 
-        # dictionary of claims in the wallet, keyed by claim id
-        claims = {c['claim_id']: c for c in result}
+        # dictionary of claims (not including supports) in the wallet, keyed by claim id
+        claims = {}
 
         # dictionary of decoded ClaimDict objects, keyed by claim id
         claim_dict_objs = {}
@@ -1543,10 +1543,7 @@ class Commands(object):
         # offline_parse_and_validate_claim_result
         for _claim_id in claims:
             claim_value = claims[_claim_id]['value']
-            if isinstance(claim_value, ClaimDict):
-                claim_dict_objs[_claim_id] = claim_value
-            else:
-                claim_dict_objs[_claim_id] = ClaimDict.load_dict(claim_value)
+            claim_dict_objs[_claim_id] = claim_value
 
         # format (and validate, unless skip_validate_signatures) the resulting claims for return
         for _claim_id, certificate_id in claim_tuples:

--- a/lbryum/commands.py
+++ b/lbryum/commands.py
@@ -820,6 +820,9 @@ class Commands(object):
         :param raw: bool
         :param decoded_claim: ClaimDict
         :param decoded_certificate: ClaimDict
+        :param skip_validate_signatures: bool, claim signature validation is not necessary for many
+        local operations and adds significant overhead to the call, ie 2200 claims can be parsed
+        in under 6 seconds without signature validation and just over a minute with it
         :return: formatted claim result
         """
 
@@ -863,6 +866,8 @@ class Commands(object):
                     claim_result['channel_name'] = channel_name
                     if validated:
                         claim_result['signature_is_valid'] = True
+                else:
+                    claim_result['signature_is_valid'] = None
 
         if 'height' in claim_result and claim_result['height'] is None:
             claim_result['height'] = -1


### PR DESCRIPTION
This changes the `getnameclaims` command to not use the inefficient (and soon deprecated) `parse_and_validate_claim_result` function when formatting claim infos. It also adds a parameter to `getnameclaims` to disable signature validation, which slows down `claim`, `update`, `abandon`, and `claimcertificate` significantly - and is not necessary since `getnameclaims` is only being used to prevent making duplicate claims or to find a particular claim in those functions. 

By default `getnameclaims` validates claim signatures, using the more efficient `getclaimsbyids` command to retrieve any certificates not in the wallet (previously all certificates were requested even if they were in the wallet). In the claim related commands where signature validation isn't needed, it is skipped.

Using a wallet with ~2200 claims, `getnameclaims` used to take ~2m30s. Now it takes 1m07s when validating signatures and 6s when signature validation is skipped.