### PR TITLE
add getleastusedaddress, better address usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,11 +22,12 @@ labeled as 2.7.1. Subsequent releases will follow
 ### Changed
   * Improved speed of `getunusedaddress`
   * Moved storage.write call in `getunusedaddress` to `Deterministic_Wallet`
-  * By default use the least used change address rather than generating new ones for claims
+  * By default use the least used change address rather than generating new ones for claims.
+  * Only consider addresses with less than 100 utxos for re-use.
 
 ### Added
   * Added `getleastusedchangeaddress` command
-  *
+  * Added `getleastusedaddress` command
 
 ### Removed
   *

--- a/lbryum/commands.py
+++ b/lbryum/commands.py
@@ -476,7 +476,11 @@ class Commands(object):
 
     @command('wp')
     def getleastusedchangeaddress(self, account=None):
-        return self.wallet.get_least_used_change_address(account)
+        return self.wallet.get_least_used_address(account, for_change=True)
+
+    @command('wp')
+    def getleastusedaddress(self, account=None):
+        return self.wallet.get_least_used_address(account)
 
     @command('wp')
     def payto(self, destination, amount, tx_fee=None, from_addr=None, change_addr=None,
@@ -1700,7 +1704,7 @@ class Commands(object):
             return {'error': 'invalid claim address'}
 
         if change_addr is None:
-            change_addr = self.wallet.get_least_used_change_address()
+            change_addr = self.wallet.get_least_used_address(for_change=True)
         if not base_decode(change_addr, ADDRESS_LENGTH, 58):
             return {'error': 'invalid change address'}
 
@@ -1872,7 +1876,7 @@ class Commands(object):
         if claim_addr is None:
             claim_addr = self.wallet.create_new_address()
         if change_addr is None:
-            change_addr = self.wallet.get_least_used_change_address()
+            change_addr = self.wallet.get_least_used_address(for_change=True)
 
         claim_id = decode_claim_id_hex(claim_id)
         amount = int(COIN * amount)
@@ -1979,7 +1983,7 @@ class Commands(object):
             return {'error': 'invalid claim address'}
 
         if change_addr is None:
-            change_addr = self.wallet.get_least_used_change_address()
+            change_addr = self.wallet.get_least_used_address(for_change=True)
         if claim_id is None or txid is None or nout is None:
             claims = self.getnameclaims(skip_validate_signatures=True)
             for claim in claims:

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -35,7 +35,7 @@ class MocWallet(object):
     def create_new_address(self, **kwargs):
         return "bScaWvgzAzFXzAcVgDDARfo9RFhdrm4pVc"
 
-    def get_least_used_change_address(self, account=None):
+    def get_least_used_address(self, account=None, for_change=False):
         return self.create_new_address()
 
 


### PR DESCRIPTION
This adds a general get_least_used_address function to the wallet, and a `getleastusedaddress` command.

Additionally, when getting a least used address, only those with a history count less than 100 will be considered - this is to lower the memory requirement for indexing the utxos by addresses

