### PR TITLE
Fix wallet storage write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ labeled as 2.7.1. Subsequent releases will follow
   *
 
 ### Fixed
-  *
+  * Use lock when performing WalletStorage.write()
   *
 
 ### Deprecated

--- a/lbryum/wallet.py
+++ b/lbryum/wallet.py
@@ -107,6 +107,10 @@ class WalletStorage(PrintError):
                 self.data.pop(key)
 
     def write(self):
+        with self.lock:
+            self._write()
+
+    def _write(self):
         if threading.currentThread().isDaemon():
             log.warning('daemon thread cannot write wallet')
             return
@@ -243,7 +247,7 @@ class Abstract_Wallet(PrintError):
             if write:
                 self.storage.write()
 
-    def save_certificate(self, claim_id, private_key, write=True):
+    def save_certificate(self, claim_id, private_key, write=False):
         certificate_keys = self.storage.get('claim_certificates') or {}
         certificate_keys[claim_id] = private_key
         self.storage.put('claim_certificates', certificate_keys)
@@ -1609,7 +1613,6 @@ class Deterministic_Wallet(Abstract_Wallet):
                 account = self.default_account()
             address = account.create_new_address(for_change)
             self.add_address(address)
-            self.storage.write()
         log.info("created address %s", address)
         return address
 


### PR DESCRIPTION
This fixes issue: https://github.com/lbryio/lbryum/issues/182

The reason why this was happening was because WalletStorage.write() is called by the network loop, which is on separate thread then the daemon (which handles commands)  and it does not acquire a lock when doing so. If you called WalletStorage.write() on the daemon thread, you ran into a race condition when WalletStorage.write() was also being called on the network loop simultaneously.

In the channel claim command, it saves the wallet immediately after creating the certificate which happened to coincide on a semi frequent basis to when the wallet would get saved by the network loop after receiving the transaction from servers.

Use WalletStorage.lock when doing WalletStroage.write() , you can see that this is done on the latest electrum code:  https://github.com/spesmilo/electrum/blob/master/lib/storage.py

There is also no need to aggressively call WalletStroage.write() , since the network loop handles this and is done on shutdown. Removed call of WalletStorage.write() when calling save_certificate() and create_new_address().
