### PR TITLE
Update license with Copyright line

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,7 @@
 The MIT License (MIT)
 
+Copyright (c) 2017-2018 LBRY Inc
+
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the
 "Software"), to deal in the Software without restriction, including


### PR DESCRIPTION
Solves #245 
Added the copyright line. Now it has the year (inclusive of 2018) along with the Org name